### PR TITLE
DMAO Admin - Delete institution admin

### DIFF
--- a/app/controllers/admin/institutions/admins_controller.rb
+++ b/app/controllers/admin/institutions/admins_controller.rb
@@ -83,6 +83,25 @@ module Admin
 
       end
 
+      def destroy
+
+        begin
+
+          institution = Institution.find(params[:institution_id])
+          @institution_admin = institution.admins.find(params[:id])
+
+          @institution_admin.destroy
+
+          redirect_to admin_institution_path institution
+
+        rescue ActiveRecord::RecordNotFound
+
+          head(:not_found)
+
+        end
+
+      end
+
       private
 
       def admin_params

--- a/app/views/admin/institutions/admins/_table.html.erb
+++ b/app/views/admin/institutions/admins/_table.html.erb
@@ -23,6 +23,9 @@
                   <%= link_to(edit_admin_institution_admin_path(@institution, admin), data: {title: "Edit", toggle: "tooltip", container: "body"}, class: "btn btn-default") do %>
                       <i class="fa fa-edit"></i>
                   <% end %>
+                  <%= link_to(admin_institution_admin_path(@institution, admin), method: :delete, data:{confirm:"Are you sure you want to delete '#{admin.name}' an institution admin for #{@institution.name}.", title: "Delete", toggle: "tooltip", container: "body"}, class: "btn btn-default") do %>
+                      <i class="fa fa-trash"></i>
+                  <% end %>
                 </div>
               </td>
             </tr>

--- a/test/controllers/admin/institutions/admins_controller_test.rb
+++ b/test/controllers/admin/institutions/admins_controller_test.rb
@@ -125,6 +125,38 @@ module Admin
 
       end
 
+      test 'Delete - return 404 when no institution found for id when deleting admin user' do
+
+        delete :destroy, params: { institution_id: 0, id: 0 }
+
+        assert_response :not_found
+
+      end
+
+      test 'Delete - return 404 when no admin user found in institution for id when deleting admin' do
+
+        delete :destroy, params: { institution_id: @institution.id, id: 0 }
+
+        assert_response :not_found
+
+      end
+
+      test 'Delete - redirects to institution details on successfully deleting an institution admin user' do
+
+        delete :destroy, params: { institution_id: @institution.id, id: @institution.admins.first.id }
+
+        assert_redirected_to admin_institution_path(@institution)
+
+      end
+
+      test 'Delete - removes an institution admin on successful delete' do
+
+        assert_difference 'Institution::Admin.unscoped.count', -1 do
+          delete :destroy, params: { institution_id: @institution.id, id: @institution.admins.first.id }
+        end
+
+      end
+
       private
 
       def valid_admin


### PR DESCRIPTION
Provides the ability for a systems admin. to remove an institution admin user from an institution.