### PR TITLE
DMAO Admin - Adding a CRIS system config for an institution

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,10 @@ gem 'nested_form_fields'
 # PaperTrail - versioning of model with log
 gem 'paper_trail'
 
+# Encryption of db field values
+
+gem 'symmetric-encryption'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,8 @@ GEM
       sshkit (~> 1.3)
     codeclimate-test-reporter (0.6.0)
       simplecov (>= 0.7.1, < 1.0.0)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     coffee-rails (4.2.1)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.2.x)
@@ -79,6 +81,8 @@ GEM
     coffee-script-source (1.10.0)
     concurrent-ruby (1.0.2)
     debug_inspector (0.0.2)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     devise (4.2.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -203,6 +207,8 @@ GEM
     sshkit (1.11.2)
       net-scp (>= 1.1.2)
       net-ssh (>= 2.8.0)
+    symmetric-encryption (3.8.3)
+      coercible (~> 1.0)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
@@ -254,6 +260,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   spring
   spring-watcher-listen (~> 2.0.0)
+  symmetric-encryption
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/app/assets/javascripts/admin/institutions/configurations.js
+++ b/app/assets/javascripts/admin/institutions/configurations.js
@@ -1,0 +1,28 @@
+$(document).on("change", "select#institution_configuration_systems_configuration_cris_system_system_id", function(select) {
+
+    $.ajax({
+        url: "/admin/systems/cris_systems/" + $(this).val() + '/config_keys',
+        dataType: "json",
+        success: function(data) {
+            $.each(data, function(index, value) {
+                $("#cris-system-configuration").append(configKeyInput(value.id, value.name, value.display_name));
+            });
+        },
+        error: function(data){
+
+        }
+    });
+
+    function configKeyInput(id, name, displayName) {
+
+        var input = "<p>";
+        input += "<label for='institution_configuration_cris_system_" + name + "'>" + displayName + "</label>";
+        input += "<br>";
+        input += "<input type='text' name='institution_configuration[systems_configuration][cris_system][configuration_key_values][" + id + "]" + "'>";
+        input += "</p>" ;
+
+        return input;
+
+    }
+
+});

--- a/app/assets/javascripts/admin/institutions/configurations.js
+++ b/app/assets/javascripts/admin/institutions/configurations.js
@@ -18,7 +18,7 @@ $(document).on("change", "select#institution_configuration_systems_configuration
                     $("#cris-system-configuration-values").append(configKeyInput(value.id, value.name, value.display_name));
                 });
             },
-            error: function(data){
+            error: function(data) {
 
             }
         });
@@ -30,7 +30,7 @@ $(document).on("change", "select#institution_configuration_systems_configuration
         var input = "<p>";
         input += "<label for='institution_configuration_cris_system_" + name + "'>" + displayName + "</label>";
         input += "<br>";
-        input += "<input type='text' name='institution_configuration[systems_configuration][cris_system][configuration_key_values][" + id + "]" + "'>";
+        input += "<input type='text' name='institution_configuration[systems_configuration][cris_system][configuration_key_values][" + id + "][value]'>";
         input += "</p>" ;
 
         return input;

--- a/app/assets/javascripts/admin/institutions/configurations.js
+++ b/app/assets/javascripts/admin/institutions/configurations.js
@@ -1,17 +1,29 @@
 $(document).on("change", "select#institution_configuration_systems_configuration_cris_system_system_id", function(select) {
 
-    $.ajax({
-        url: "/admin/systems/cris_systems/" + $(this).val() + '/config_keys',
-        dataType: "json",
-        success: function(data) {
-            $.each(data, function(index, value) {
-                $("#cris-system-configuration").append(configKeyInput(value.id, value.name, value.display_name));
-            });
-        },
-        error: function(data){
+    $("#cris-system-configuration-values").empty();
 
-        }
-    });
+    if ($(this).val() !== "") {
+
+        loadConfigKeysForSystem($(this).val())
+
+    }
+
+    function loadConfigKeysForSystem(system_id) {
+
+        $.ajax({
+            url: "/admin/systems/cris_systems/" + system_id + '/config_keys',
+            dataType: "json",
+            success: function(data) {
+                $.each(data, function(index, value) {
+                    $("#cris-system-configuration-values").append(configKeyInput(value.id, value.name, value.display_name));
+                });
+            },
+            error: function(data){
+
+            }
+        });
+
+    }
 
     function configKeyInput(id, name, displayName) {
 

--- a/app/controllers/admin/institutions/configurations_controller.rb
+++ b/app/controllers/admin/institutions/configurations_controller.rb
@@ -18,6 +18,63 @@ module Admin
 
       end
 
+      def create
+
+        begin
+
+          @institution = Institution.find(params[:institution_id])
+
+        rescue ActiveRecord::RecordNotFound
+
+          return head(:not_found)
+
+        end
+
+        # create config object
+
+        systems_configuration = ::CreateSystemsConfiguration.new(@institution, configuration_params[:systems_configuration].to_h).call
+
+        @configuration = ::Institution::Configuration.new(institution_id: @institution.id)
+
+        if systems_configuration.errors.any?
+
+          @configuration.errors.add(:systems_configuration, systems_configuration.errors)
+
+        else
+
+          @configuration.systems_configuration = systems_configuration
+
+          if @configuration.save
+
+            return redirect_to admin_institution_configuration_path(institution_id: @institution.id, id: @configuration.id)
+
+          end
+
+        end
+
+        render 'new'
+
+      end
+
+      private
+
+      def configuration_params
+
+        params
+            .require(:institution_configuration)
+            .permit(
+                systems_configuration: [
+                    cris_system: [
+                        :system_id,
+                        configuration_key_values: [
+                            :value
+                        ]
+                    ]
+                ]
+            )
+
+      end
+
     end
   end
 end

--- a/app/controllers/admin/institutions/configurations_controller.rb
+++ b/app/controllers/admin/institutions/configurations_controller.rb
@@ -1,0 +1,23 @@
+module Admin
+  module Institutions
+    class ConfigurationsController < ::Admin::AdminController
+
+      def new
+
+        begin
+
+          @institution = Institution.find params[:institution_id]
+
+          @configuration = @institution.configuration || Institution::Configuration.new(institution: @institution)
+
+        rescue ActiveRecord::RecordNotFound
+
+          head(:not_found)
+
+        end
+
+      end
+
+    end
+  end
+end

--- a/app/controllers/admin/systems/cris_systems_controller.rb
+++ b/app/controllers/admin/systems/cris_systems_controller.rb
@@ -40,6 +40,26 @@ module Admin
 
       end
 
+      def config_keys
+
+        begin
+
+          cris_system = ::Systems::CrisSystem.find(params[:id])
+
+          @config_keys = cris_system.configuration_keys
+
+          respond_to do |format|
+            format.json { render json: @config_keys }
+          end
+
+        rescue ActiveRecord::RecordNotFound, ActionController::UnknownFormat
+
+          head(:not_found)
+
+        end
+
+      end
+
       private
 
       def cris_system_params

--- a/app/models/configuration/system/cris_system.rb
+++ b/app/models/configuration/system/cris_system.rb
@@ -7,7 +7,6 @@ module Configuration
       attr_accessor :system_id, :config_values
 
       validates :system_id, numericality: true
-      validates :config_values, presence: true
       validate :config_values_array
 
       def initialize(attributes={})

--- a/app/models/configuration/system/cris_system.rb
+++ b/app/models/configuration/system/cris_system.rb
@@ -11,21 +11,7 @@ module Configuration
 
       def initialize(attributes={})
 
-        attributes = attributes.dup unless attributes.nil?
-
-        if attributes.present?
-
-          attributes.each do |k,v|
-
-            if v.nil?
-              attributes.delete(k)
-            end
-
-          end
-
-        end
-
-        attributes.delete(:configuration_key_values) unless attributes.nil?
+        attributes = clean_up_attributes attributes
 
         super
 
@@ -47,6 +33,32 @@ module Configuration
 
       def config_values_array
         errors.add(:config_values, 'Must be an array of config value ids') unless config_values.is_a?(Array)
+      end
+
+      def clean_up_attributes attributes
+
+        attributes = attributes.dup unless attributes.nil?
+
+        attributes = remove_nil_attributes attributes
+
+        attributes.delete(:configuration_key_values) unless attributes.nil?
+
+        attributes
+
+      end
+
+      def remove_nil_attributes attributes
+
+        return attributes unless attributes.present?
+
+        attributes.each do |k,v|
+
+          v.nil? ? attributes.delete(k) : ''
+
+        end
+
+        attributes
+
       end
 
     end

--- a/app/models/configuration/system/cris_system.rb
+++ b/app/models/configuration/system/cris_system.rb
@@ -13,6 +13,18 @@ module Configuration
 
         attributes = attributes.dup unless attributes.nil?
 
+        if attributes.present?
+
+          attributes.each do |k,v|
+
+            if v.nil?
+              attributes.delete(k)
+            end
+
+          end
+
+        end
+
         attributes.delete(:configuration_key_values) unless attributes.nil?
 
         super

--- a/app/models/configuration/system/cris_system.rb
+++ b/app/models/configuration/system/cris_system.rb
@@ -11,10 +11,17 @@ module Configuration
       validate :config_values_array
 
       def initialize(attributes={})
+
+        attributes = attributes.dup unless attributes.nil?
+
+        attributes.delete(:configuration_key_values) unless attributes.nil?
+
         super
+
         if @config_values.nil? || @config_values.empty? || !@config_values.is_a?(Array)
           @config_values = []
         end
+
       end
 
       def add_config_value id

--- a/app/models/institution.rb
+++ b/app/models/institution.rb
@@ -9,5 +9,6 @@ class Institution < ApplicationRecord
   has_many :admins, class_name: 'Institution::Admin'
   has_many :users, class_name: 'Institution::User'
   has_one :configuration, :class_name => 'Institution::Configuration'
+  has_many :configuration_values, :class_name => 'Systems::ConfigurationValue', dependent: :destroy
 
 end

--- a/app/models/institution/configuration.rb
+++ b/app/models/institution/configuration.rb
@@ -15,7 +15,7 @@ class Institution::Configuration < ApplicationRecord
       systems_config = ::Configuration::SystemConfiguration.new value
     end
 
-    super(systems_config.to_json)
+    super(systems_config.to_json(except: ["errors", :errors]))
 
   end
 

--- a/app/models/systems/configuration_value.rb
+++ b/app/models/systems/configuration_value.rb
@@ -1,0 +1,13 @@
+class Systems::ConfigurationValue < ApplicationRecord
+
+  attr_encrypted :value
+
+  validates :institution, presence: true
+  validates :configuration_key, presence: true
+
+  validates :encrypted_value, presence: true, symmetric_encryption: true
+
+  belongs_to :institution, :class_name => 'Institution'
+  belongs_to :configuration_key, foreign_key: "systems_configuration_key_id", :class_name => 'Systems::ConfigurationKey'
+
+end

--- a/app/services/create_systems_configuration.rb
+++ b/app/services/create_systems_configuration.rb
@@ -37,7 +37,7 @@ class CreateSystemsConfiguration
 
     # check configurations key values are set for all config keys else errors
 
-    config_key_values.each do |k,v|
+    config_key_values.keys.each do |k|
 
       if config_key_ids.include?(k.to_i)
 

--- a/app/services/create_systems_configuration.rb
+++ b/app/services/create_systems_configuration.rb
@@ -1,0 +1,61 @@
+class CreateSystemsConfiguration
+
+  def initialize institution, configuration_hash
+    @institution = institution
+    @configuration_hash = configuration_hash
+  end
+
+
+  def call
+
+    # create system config object with cris system config
+
+    systems_configuration = ::Configuration::SystemConfiguration.new @configuration_hash
+
+    config_key_values = @configuration_hash[:cris_system][:configuration_key_values]
+
+    # get cris system - should be wrapped in rescue block in case not found
+
+    cris_system = ::Systems::CrisSystem.find(systems_configuration.cris_system.system_id)
+
+    config_key_ids = cris_system.configuration_keys.ids
+
+    # check configurations key values are set for all config keys else errors
+
+    config_key_values.each do |k,v|
+
+      if config_key_ids.include?(k.to_i)
+
+      else
+
+        config_key_values.delete(k)
+
+        systems_configuration.errors.add(:cris_system, "Invalid configuration keys for choosen CRIS System specified.")
+
+      end
+
+    end
+
+    if systems_configuration.errors.any?
+      return systems_configuration
+    end
+
+    # Store configuration key values
+
+    config_key_values.each_pair do |k, v|
+
+      key = ::Systems::ConfigurationKey.find(k.to_i)
+
+      config_value = ::Systems::ConfigurationValue.create(institution: @institution, configuration_key: key, value: v["value"])
+
+      # set cris system configuration key
+
+      systems_configuration.cris_system.add_config_value config_value.id
+
+    end
+
+    systems_configuration
+
+  end
+
+end

--- a/app/views/admin/institutions/configurations/new.html.erb
+++ b/app/views/admin/institutions/configurations/new.html.erb
@@ -1,0 +1,28 @@
+<% content_for :title, 'New Institution Configuration' %>
+
+<%= form_for @configuration, url: admin_institution_configurations_path(@institution) do |f| %>
+
+    <div id="systems-configuration">
+
+      <%= f.fields_for :systems_configuration do |system_config| %>
+
+      <div id="cris-system-configuration">
+
+        <%= system_config.fields_for :cris_system do |cris_config| %>
+
+          <p>
+            <%= f.label :system_id, 'CRIS System' %><br>
+            <%= cris_config.collection_select :system_id, Systems::CrisSystem.all, :id, :name, include_blank: 'Choose CRIS System' %>
+          </p>
+
+        <% end %>
+
+      </div>
+
+      <% end %>
+
+    </div>
+
+    <p><%= f.submit %></p>
+
+<% end %>

--- a/app/views/admin/institutions/configurations/new.html.erb
+++ b/app/views/admin/institutions/configurations/new.html.erb
@@ -17,6 +17,8 @@
 
         <% end %>
 
+        <div id="cris-system-configuration-values"></div>
+
       </div>
 
       <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,7 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :institutions do
       resources :admins, controller: 'institutions/admins'
+      resources :configurations, controller: 'institutions/configurations'
     end
     namespace :systems do
       resources :cris_systems, controller: 'cris_systems'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
     end
     namespace :systems do
       resources :cris_systems, controller: 'cris_systems'
+      get 'cris_systems/:id/config_keys', to: 'cris_systems#config_keys'
     end
   end
 

--- a/config/symmetric-encryption.yml
+++ b/config/symmetric-encryption.yml
@@ -1,0 +1,60 @@
+#
+# Symmetric Encryption for Ruby
+#
+---
+# For the development and test environments the test symmetric encryption keys
+# can be placed directly in the source code.
+# And therefore no RSA private key is required
+development:         &development_defaults
+  key:               1234567890ABCDEF1234567890ABCDEF
+  iv:                1234567890ABCDEF
+  cipher_name:       aes-128-cbc
+  encoding:          :base64strict
+  always_add_header: true
+
+test:
+  <<: *development_defaults
+
+release:
+  # Since the key to encrypt and decrypt with must NOT be stored along with the
+  # source code, we only hold a RSA key that is used to unlock the file
+  # containing the actual symmetric encryption key
+  private_rsa_key: |
+    -----BEGIN RSA PRIVATE KEY-----
+
+    -----END RSA PRIVATE KEY-----
+
+
+  # List Symmetric Key files in the order of current / latest first
+  ciphers:
+    -
+      # Filename containing Symmetric Encryption Key encrypted using the
+      # RSA public key derived from the private key above
+      key_filename:      /etc/rails/keys/dmao_release.key
+      iv_filename:       /etc/rails/keys/dmao_release.iv
+      cipher_name:       aes-256-cbc
+      encoding:          :base64strict
+      version:           1
+      always_add_header: true
+
+production:
+  # Since the key to encrypt and decrypt with must NOT be stored along with the
+  # source code, we only hold a RSA key that is used to unlock the file
+  # containing the actual symmetric encryption key
+  private_rsa_key: |
+    -----BEGIN RSA PRIVATE KEY-----
+
+    -----END RSA PRIVATE KEY-----
+
+
+  # List Symmetric Key files in the order of current / latest first
+  ciphers:
+    -
+      # Filename containing Symmetric Encryption Key encrypted using the
+      # RSA public key derived from the private key above
+      key_filename:      /etc/rails/keys/dmao_production.key
+      iv_filename:       /etc/rails/keys/dmao_production.iv
+      cipher_name:       aes-256-cbc
+      encoding:          :base64strict
+      version:           1
+      always_add_header: true

--- a/db/migrate/20160915134500_create_systems_configuration_values.rb
+++ b/db/migrate/20160915134500_create_systems_configuration_values.rb
@@ -1,0 +1,11 @@
+class CreateSystemsConfigurationValues < ActiveRecord::Migration[5.0]
+  def change
+    create_table :systems_configuration_values do |t|
+      t.string :encrypted_value
+      t.references :institution, foreign_key: true
+      t.references :systems_configuration_key, foreign_key: true, index: { name: 'index_configuration_values_on_configuration_key_id' }
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160913141024) do
+ActiveRecord::Schema.define(version: 20160915134500) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -115,6 +115,16 @@ ActiveRecord::Schema.define(version: 20160913141024) do
     t.index ["systemable_type", "systemable_id"], name: "index_systems_configuration_keys_on_systemable", using: :btree
   end
 
+  create_table "systems_configuration_values", force: :cascade do |t|
+    t.string   "encrypted_value"
+    t.integer  "institution_id"
+    t.integer  "systems_configuration_key_id"
+    t.datetime "created_at",                   null: false
+    t.datetime "updated_at",                   null: false
+    t.index ["institution_id"], name: "index_systems_configuration_values_on_institution_id", using: :btree
+    t.index ["systems_configuration_key_id"], name: "index_configuration_values_on_configuration_key_id", using: :btree
+  end
+
   create_table "systems_cris_systems", force: :cascade do |t|
     t.string   "name"
     t.text     "description"
@@ -133,4 +143,6 @@ ActiveRecord::Schema.define(version: 20160913141024) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id", using: :btree
   end
 
+  add_foreign_key "systems_configuration_values", "institutions"
+  add_foreign_key "systems_configuration_values", "systems_configuration_keys"
 end

--- a/test/controllers/admin/institutions/configurations_controller_test.rb
+++ b/test/controllers/admin/institutions/configurations_controller_test.rb
@@ -100,6 +100,16 @@ module Admin
 
       end
 
+      test 'Create - should show form if error creating systems configuration' do
+
+        ::Configuration::SystemConfiguration.any_instance.expects(:errors).at_least_once.returns(fake_errors_object)
+
+        post :create, params: valid_configuration_params
+
+        assert_template :new
+
+      end
+
       private
 
       def valid_configuration_params
@@ -123,6 +133,16 @@ module Admin
                 }
             }
         }
+      end
+
+      def fake_errors_object
+
+        errors = ActiveModel::Errors.new(self)
+
+        errors.add(:testing, "TESTING ERROR")
+
+        errors
+
       end
 
     end

--- a/test/controllers/admin/institutions/configurations_controller_test.rb
+++ b/test/controllers/admin/institutions/configurations_controller_test.rb
@@ -1,0 +1,52 @@
+require 'test_helper'
+
+module Admin
+  module Institutions
+
+    class ConfigurationsControllerTest < ActionController::TestCase
+
+      include Devise::Test::ControllerHelpers
+
+      def setup
+
+        @request.env['devise.mapping'] = Devise.mappings[:dmao_admin]
+        sign_in dmao_admins(:one)
+
+        @institution = institutions(:luve)
+
+      end
+
+      test 'New - assigns configuration to that of the institution when it exists' do
+
+        get :new, params: { institution_id: @institution.id }
+
+        assert_equal @institution.configuration, assigns(:configuration)
+
+      end
+
+      test 'New - assigns empty configuration if one does not exist for institution' do
+
+        test_institution = institutions(:test)
+
+        get :new, params: { institution_id: test_institution.id }
+
+        configuration = assigns(:configuration)
+
+        assert_instance_of Institution::Configuration, configuration
+        assert_equal test_institution.id, configuration.institution_id
+        assert_instance_of ::Configuration::SystemConfiguration, configuration.systems_configuration
+
+      end
+
+      test 'New - returns 404 if institution does not exist' do
+
+        get :new, params: { institution_id: 0 }
+
+        assert_response :not_found
+
+      end
+
+    end
+
+  end
+end

--- a/test/controllers/admin/systems/cris_systems_controller_test.rb
+++ b/test/controllers/admin/systems/cris_systems_controller_test.rb
@@ -159,6 +159,32 @@ module Admin
 
       end
 
+      test 'Config Keys - should 404 if cannot find cris system for id' do
+
+        get :config_keys, params: { id: 0 }
+
+        assert_response :not_found
+
+      end
+
+      test 'Config Keys - should return 404 not found when requesting as html' do
+
+        get :config_keys, params: { id: @cris_system.id }
+
+        assert_response :not_found
+
+      end
+
+      test 'Config Keys - should return json when requesting as json' do
+
+        @request.env['HTTP_ACCEPT'] = 'application/json'
+
+        get :config_keys, params: { id: @cris_system.id }
+
+        assert_response :ok
+
+      end
+
     end
   end
 end

--- a/test/fixtures/systems/configuration_values.yml
+++ b/test/fixtures/systems/configuration_values.yml
@@ -1,0 +1,6 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  encrypted_value: QEVuQwAA0tBPvmEexI5toAd9PeJyLw==
+  institution: luve
+  configuration_key: one

--- a/test/models/configuration/system/cris_system_test.rb
+++ b/test/models/configuration/system/cris_system_test.rb
@@ -19,11 +19,6 @@ module Configuration
         refute @cris_system.valid?
       end
 
-      test 'Should be invalid without config values' do
-        @cris_system.config_values = nil
-        refute @cris_system.valid?
-      end
-
       test 'Should be invalid if config values is not an array' do
         @cris_system.config_values = "STRING"
         refute @cris_system.valid?

--- a/test/models/systems/configuration_value_test.rb
+++ b/test/models/systems/configuration_value_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+
+class Systems::ConfigurationValueTest < ActiveSupport::TestCase
+
+  def setup
+
+    @config_value = systems_configuration_values(:one)
+
+  end
+
+  test "is a valid configuration value" do
+
+    assert @config_value.valid?
+
+  end
+
+  test 'is invalid without an institution' do
+
+    @config_value.institution = nil
+
+    refute @config_value.valid?
+
+  end
+
+  test 'is invalid without a configuration key' do
+
+    @config_value.configuration_key = nil
+
+    refute @config_value.valid?
+
+  end
+
+  test 'value should be stored encrypted' do
+
+    @config_value.encrypted_value = "testing1234"
+
+    refute @config_value.valid?
+
+  end
+
+end

--- a/test/services/create_systems_configuration_test.rb
+++ b/test/services/create_systems_configuration_test.rb
@@ -1,0 +1,195 @@
+require 'test_helper'
+
+class CreateSystemsConfigurationTest < ActiveSupport::TestCase
+
+  def setup
+
+    @institution = institutions(:test)
+
+    @configuration_hash = configuration_hash
+
+  end
+
+  test 'when initialised should accept institution and configuration hash parameters' do
+
+    create_system_configuration = CreateSystemsConfiguration.new(@institution, @configuration_hash)
+
+    assert_instance_of CreateSystemsConfiguration, create_system_configuration
+
+  end
+
+  test 'should call new on system configuration with configuration hash' do
+
+    new_system_config = Configuration::SystemConfiguration.new
+
+    Configuration::SystemConfiguration.expects(:new).once.with(@configuration_hash).returns(new_system_config)
+
+    create_system_configuration = CreateSystemsConfiguration.new(@institution, @configuration_hash)
+
+    create_system_configuration.call
+
+  end
+
+  test 'should return system configuration with errors if cris system configuration is invalid' do
+
+    Configuration::System::CrisSystem.any_instance.expects(:valid?).once.returns(false)
+
+    create_system_configuration = CreateSystemsConfiguration.new(@institution, @configuration_hash)
+
+    response = create_system_configuration.call
+
+    assert_instance_of Configuration::SystemConfiguration, response
+
+    assert_instance_of ActiveModel::Errors, response.errors
+
+    assert_includes response.errors, :cris_system
+
+  end
+
+  test 'should return error if cris system cannot be found for cris system id' do
+
+    Systems::CrisSystem.expects(:find).once.raises(ActiveRecord::RecordNotFound)
+
+    create_system_configuration = CreateSystemsConfiguration.new(@institution, @configuration_hash)
+
+    response = create_system_configuration.call
+
+    assert_instance_of Configuration::SystemConfiguration, response
+
+    assert_instance_of ActiveModel::Errors, response.errors
+
+    assert_includes response.errors, :cris_system
+
+  end
+
+  test 'should return error if config key value is for an invalid config key id' do
+
+    i = 0
+    config_key_values = {}
+
+    @configuration_hash[:cris_system][:configuration_key_values].each do |k, v|
+
+      config_key_values[i] = v
+
+      i += 1
+
+    end
+
+    @configuration_hash[:cris_system][:configuration_key_values] = config_key_values
+
+    create_system_configuration = CreateSystemsConfiguration.new(@institution, @configuration_hash)
+
+    response = create_system_configuration.call
+
+    assert_instance_of Configuration::SystemConfiguration, response
+
+    assert_instance_of ActiveModel::Errors, response.errors
+
+    assert_includes response.errors, :cris_system
+
+    assert_includes response.errors[:cris_system], "Invalid configuration keys for choosen CRIS System specified."
+
+  end
+
+  test 'if systems configuration has errors should return with errors' do
+
+    Configuration::SystemConfiguration.any_instance.expects(:errors).at_least_once.returns(fake_errors_object)
+
+    create_system_configuration = CreateSystemsConfiguration.new(@institution, @configuration_hash)
+
+    response = create_system_configuration.call
+
+    assert_instance_of Configuration::SystemConfiguration, response
+
+    assert_instance_of ActiveModel::Errors, response.errors
+
+  end
+
+  test 'should call create on system configuration value for number of keys existing in configuration hash' do
+
+    number_of_config_keys = @configuration_hash[:cris_system][:configuration_key_values].length
+
+    created_config_value = Systems::ConfigurationValue.new(institution: @institution, value: "Testing")
+
+    Systems::ConfigurationValue.expects(:create).times(number_of_config_keys).returns(created_config_value)
+
+    create_system_configuration = CreateSystemsConfiguration.new(@institution, @configuration_hash)
+
+    response = create_system_configuration.call
+
+    assert_instance_of Configuration::SystemConfiguration, response
+
+    assert_instance_of ActiveModel::Errors, response.errors
+
+    assert_not response.errors.any?
+
+  end
+
+  test 'should increase configuration value config for number of keys specified' do
+
+    number_of_config_keys = @configuration_hash[:cris_system][:configuration_key_values].length
+
+    assert_difference "Systems::ConfigurationValue.count", number_of_config_keys do
+
+      create_system_configuration = CreateSystemsConfiguration.new(@institution, @configuration_hash)
+
+      response = create_system_configuration.call
+
+    end
+
+  end
+
+  test 'should call add config value for cris system with id of stored config value' do
+
+    number_of_config_keys = @configuration_hash[:cris_system][:configuration_key_values].length
+
+    created_config_value = Systems::ConfigurationValue.new(institution: @institution, value: "Testing", id: 1234)
+
+    Systems::ConfigurationValue.expects(:create).times(number_of_config_keys).returns(created_config_value)
+
+    Configuration::System::CrisSystem.any_instance.expects(:add_config_value).times(number_of_config_keys).with(created_config_value.id)
+
+    create_system_configuration = CreateSystemsConfiguration.new(@institution, @configuration_hash)
+
+    response = create_system_configuration.call
+
+    assert_instance_of Configuration::SystemConfiguration, response
+
+    assert_instance_of ActiveModel::Errors, response.errors
+
+    assert_not response.errors.any?
+
+  end
+
+  private
+
+  def configuration_hash
+
+    cris_system = systems_cris_systems(:one)
+
+    config_key_ids = cris_system.configuration_keys.ids
+
+    config_values = {}
+
+    config_key_ids.each { |id| config_values[id.to_s] = { value: "testing key #{id} value" } }
+
+    {
+      cris_system: {
+        system_id: cris_system.id,
+        configuration_key_values: config_values
+      }
+    }
+
+  end
+
+  def fake_errors_object
+
+    errors = ActiveModel::Errors.new(self)
+
+    errors.add(:testing, "TESTING ERROR")
+
+    errors
+
+  end
+
+end


### PR DESCRIPTION
Within the DMAO Admin area provides a form to choose the institution CRIS system and set the different config keys required for the chosen CRIS system, this is then submitted and stored as a new version of the institution configuration.