### PR TITLE
New institution configuration form errors

### DIFF
--- a/app/controllers/admin/institutions/configurations_controller.rb
+++ b/app/controllers/admin/institutions/configurations_controller.rb
@@ -34,7 +34,7 @@ module Admin
 
         systems_configuration = ::CreateSystemsConfiguration.new(@institution, configuration_params[:systems_configuration].to_h).call
 
-        @configuration = ::Institution::Configuration.new(institution_id: @institution.id)
+        @configuration = @institution.configuration || Institution::Configuration.new(institution: @institution)
 
         if systems_configuration.errors.any?
 
@@ -52,7 +52,9 @@ module Admin
 
         end
 
-        render 'new'
+        @configuration_params = configuration_params
+
+        render 'new-errors'
 
       end
 

--- a/app/controllers/admin/systems/cris_systems_controller.rb
+++ b/app/controllers/admin/systems/cris_systems_controller.rb
@@ -64,7 +64,7 @@ module Admin
 
       def cris_system_params
 
-        params.require(:systems_cris_system).permit(:name, :description, :version, configuration_keys_attributes: [:name, :display_name])
+        params.require(:systems_cris_system).permit(:name, :description, :version, configuration_keys_attributes: [:name, :display_name, :secure])
 
       end
 

--- a/app/helpers/configuration_key_helper.rb
+++ b/app/helpers/configuration_key_helper.rb
@@ -1,0 +1,51 @@
+module ConfigurationKeyHelper
+
+  def configuration_key_id_name id
+
+    begin
+
+      key = Systems::ConfigurationKey.find(id)
+
+      key.display_name
+
+    rescue ActiveRecord::RecordNotFound
+
+      nil
+
+    end
+
+  end
+
+  def configuration_key_id_slug id
+
+    begin
+
+      key = Systems::ConfigurationKey.find(id)
+
+      key.name
+
+    rescue ActiveRecord::RecordNotFound
+
+      nil
+
+    end
+
+  end
+
+  def configuration_key_id_secure id
+
+    begin
+
+      key = Systems::ConfigurationKey.find(id)
+
+      false
+
+    rescue ActiveRecord::RecordNotFound
+
+      false
+
+    end
+
+  end
+
+end

--- a/app/helpers/configuration_key_helper.rb
+++ b/app/helpers/configuration_key_helper.rb
@@ -36,7 +36,9 @@ module ConfigurationKeyHelper
 
     begin
 
-      false
+      key = Systems::ConfigurationKey.find(id)
+
+      key.secure
 
     rescue ActiveRecord::RecordNotFound
 

--- a/app/helpers/configuration_key_helper.rb
+++ b/app/helpers/configuration_key_helper.rb
@@ -42,7 +42,7 @@ module ConfigurationKeyHelper
 
     rescue ActiveRecord::RecordNotFound
 
-      false
+      nil
 
     end
 

--- a/app/helpers/configuration_key_helper.rb
+++ b/app/helpers/configuration_key_helper.rb
@@ -36,8 +36,6 @@ module ConfigurationKeyHelper
 
     begin
 
-      key = Systems::ConfigurationKey.find(id)
-
       false
 
     rescue ActiveRecord::RecordNotFound

--- a/app/models/systems/configuration_key.rb
+++ b/app/models/systems/configuration_key.rb
@@ -8,4 +8,12 @@ class Systems::ConfigurationKey < ApplicationRecord
 
   belongs_to :systemable, polymorphic: true
 
+  after_initialize :set_secure_default
+
+  def set_secure_default
+
+    self.secure ||= false
+
+  end
+
 end

--- a/app/views/admin/institutions/configurations/new-errors.html.erb
+++ b/app/views/admin/institutions/configurations/new-errors.html.erb
@@ -1,0 +1,46 @@
+<% content_for :title, 'New Institution Configuration' %>
+
+<%= form_for @configuration, url: admin_institution_configurations_path(@institution) do |f| %>
+
+    <div id="systems-configuration">
+
+      <%= f.fields_for :systems_configuration do |system_config| %>
+
+          <div id="cris-system-configuration">
+
+            <%= system_config.fields_for :cris_system do |cris_config| %>
+
+                <p>
+                  <%= f.label :system_id, 'CRIS System' %><br>
+                  <%= cris_config.collection_select :system_id, Systems::CrisSystem.all, :id, :name, include_blank: 'Choose CRIS System', selected: @configuration_params[:systems_configuration][:cris_system][:system_id] %>
+                </p>
+
+            <% end %>
+
+            <div id="cris-system-configuration-values">
+
+              <% @configuration_params[:systems_configuration][:cris_system][:configuration_key_values].each do |k, v| %>
+
+                  <% if configuration_key_id_name(k).present? %>
+
+                    <p>
+                      <label for="institution_configuration_cris_system_<%= configuration_key_id_slug(k) %>"><%= configuration_key_id_name(k) %></label>
+                      <br>
+                      <input type="text" name="institution_configuration[systems_configuration][cris_system][configuration_key_values][<%= k %>][value]" value="<%= configuration_key_id_secure(k) ? "" : v[:value] %>">
+                    </p>
+
+                  <% end %>
+
+              <% end %>
+
+            </div>
+
+          </div>
+
+      <% end %>
+
+    </div>
+
+    <p><%= f.submit %></p>
+
+<% end %>

--- a/app/views/admin/systems/cris_systems/_form.html.erb
+++ b/app/views/admin/systems/cris_systems/_form.html.erb
@@ -43,6 +43,11 @@
           <%= config_keys.text_field :display_name %>
         </p>
 
+        <p>
+          <%= config_keys.label :secure %><br>
+          <%= config_keys.check_box :secure %>
+        </p>
+
     <% end %>
 
     <%= f.add_nested_fields_link :configuration_keys, 'Add another config key' %>

--- a/db/migrate/20160919120806_add_secure_to_systems_configuration_key.rb
+++ b/db/migrate/20160919120806_add_secure_to_systems_configuration_key.rb
@@ -1,0 +1,5 @@
+class AddSecureToSystemsConfigurationKey < ActiveRecord::Migration[5.0]
+  def change
+    add_column :systems_configuration_keys, :secure, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160915134500) do
+ActiveRecord::Schema.define(version: 20160919120806) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -112,6 +112,7 @@ ActiveRecord::Schema.define(version: 20160915134500) do
     t.integer  "systemable_id"
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
+    t.boolean  "secure"
     t.index ["systemable_type", "systemable_id"], name: "index_systems_configuration_keys_on_systemable", using: :btree
   end
 

--- a/test/controllers/admin/institutions/configurations_controller_test.rb
+++ b/test/controllers/admin/institutions/configurations_controller_test.rb
@@ -12,15 +12,17 @@ module Admin
         @request.env['devise.mapping'] = Devise.mappings[:dmao_admin]
         sign_in dmao_admins(:one)
 
-        @institution = institutions(:luve)
+        @institution = institutions(:test)
 
       end
 
       test 'New - assigns configuration to that of the institution when it exists' do
 
-        get :new, params: { institution_id: @institution.id }
+        institution = institutions(:luve)
 
-        assert_equal @institution.configuration, assigns(:configuration)
+        get :new, params: { institution_id: institution.id }
+
+        assert_equal institution.configuration, assigns(:configuration)
 
       end
 
@@ -78,7 +80,7 @@ module Admin
 
         post :create, params: valid_configuration_params
 
-        assert_template :new
+        assert_template "new-errors"
 
       end
 
@@ -106,7 +108,7 @@ module Admin
 
         post :create, params: valid_configuration_params
 
-        assert_template :new
+        assert_template "new-errors"
 
       end
 

--- a/test/controllers/admin/systems/cris_systems_controller_test.rb
+++ b/test/controllers/admin/systems/cris_systems_controller_test.rb
@@ -109,6 +109,27 @@ module Admin
 
       end
 
+      test 'Create - should add configuration key with secure set to true when secure specified' do
+
+        post :create, params: {
+            systems_cris_system: {
+                name: 'Testing System',
+                description: 'Testing CRIS Systems',
+                version: 1,
+                configuration_keys_attributes: {
+                    "0": {
+                        name: 'testing-key-name',
+                        display_name: 'Testing key name',
+                        secure: true
+                    }
+                }
+            }
+        }
+
+        assert ::Systems::CrisSystem.last.configuration_keys.first.secure
+
+      end
+
       test 'Show - should assign cris system' do
 
         get :show, params: { id: @cris_system.id }

--- a/test/fixtures/systems/configuration_keys.yml
+++ b/test/fixtures/systems/configuration_keys.yml
@@ -3,6 +3,7 @@
 one:
   name: MyString
   display_name: MyString
+  secure: true
   systemable: one (Systems::CrisSystem)
 
 two:

--- a/test/helpers/configuration_key_helper_test.rb
+++ b/test/helpers/configuration_key_helper_test.rb
@@ -1,0 +1,47 @@
+require 'test_helper'
+
+class ConfigurationKeyHelperTest < ActionView::TestCase
+
+  def setup
+
+    @configuration_key = systems_configuration_keys(:one)
+
+  end
+
+  test 'should return nil for invalid configuration key id when requesting name' do
+
+    @configuration_key.id = 0
+
+    assert_nil configuration_key_id_name @configuration_key.id
+
+  end
+
+  test 'should return nil for invalid configuration key id when requesting slug' do
+
+    @configuration_key.id = 0
+
+    assert_nil configuration_key_id_slug @configuration_key.id
+
+  end
+
+  test 'should return nil for invalid configuration key id when requesting secure' do
+
+    @configuration_key.id = 0
+
+    assert_nil configuration_key_id_secure @configuration_key.id
+
+  end
+
+  test 'should return configuration key display name when requesting name' do
+
+    assert_equal @configuration_key.display_name, configuration_key_id_name(@configuration_key.id)
+
+  end
+
+  test 'should return configuration key name when requesting slug' do
+
+    assert_equal @configuration_key.name, configuration_key_id_slug(@configuration_key.id)
+
+  end
+
+end

--- a/test/helpers/configuration_key_helper_test.rb
+++ b/test/helpers/configuration_key_helper_test.rb
@@ -24,11 +24,10 @@ class ConfigurationKeyHelperTest < ActionView::TestCase
 
   end
 
-  test 'should return nil for invalid configuration key id when requesting secure' do
+  test 'should return false for all configuration key secure calls' do
 
-    @configuration_key.id = 0
-
-    assert_nil configuration_key_id_secure @configuration_key.id
+    assert_not configuration_key_id_secure 0
+    assert_not configuration_key_id_secure @configuration_key.id
 
   end
 

--- a/test/helpers/configuration_key_helper_test.rb
+++ b/test/helpers/configuration_key_helper_test.rb
@@ -24,10 +24,11 @@ class ConfigurationKeyHelperTest < ActionView::TestCase
 
   end
 
-  test 'should return false for all configuration key secure calls' do
+  test 'should return nil for invalid configuration key when requesting secure' do
 
-    assert_not configuration_key_id_secure 0
-    assert_not configuration_key_id_secure @configuration_key.id
+    @configuration_key.id = 0
+
+    assert_nil configuration_key_id_slug @configuration_key.id
 
   end
 
@@ -40,6 +41,12 @@ class ConfigurationKeyHelperTest < ActionView::TestCase
   test 'should return configuration key name when requesting slug' do
 
     assert_equal @configuration_key.name, configuration_key_id_slug(@configuration_key.id)
+
+  end
+
+  test 'should return configuration key secure when requesting secure' do
+
+    assert_equal @configuration_key.secure, configuration_key_id_secure(@configuration_key.id)
 
   end
 

--- a/test/models/systems/configuration_key_test.rb
+++ b/test/models/systems/configuration_key_test.rb
@@ -59,4 +59,28 @@ class Systems::ConfigurationKeyTest < ActiveSupport::TestCase
 
   end
 
+  test 'set secure default should return false when secure is nil' do
+
+    @configuration_key.secure = nil
+
+    assert_not @configuration_key.set_secure_default
+
+  end
+
+  test 'set secure default should return true when secure is true' do
+
+    @configuration_key.secure = true
+
+    assert @configuration_key.set_secure_default
+
+  end
+
+  test 'set secure default should return false when secure is false' do
+
+    @configuration_key.secure = false
+
+    assert_not @configuration_key.set_secure_default
+
+  end
+
 end


### PR DESCRIPTION
Displaying the configuration form with all selected values and what was entered on return when there are errors with the entered data.

Provides a helper to give information on the configuration key when building up the form from sent configuration params.