### PR TITLE
Registering Ingesters

### DIFF
--- a/app/lib/dmao/ingesters.rb
+++ b/app/lib/dmao/ingesters.rb
@@ -9,7 +9,7 @@ module DMAO
 
       details = { name: name, display_name: display_name, version: version, type: type }
 
-      ALL.insert -1, name
+      ALL.insert(-1, name)
       DETAILS[name] = details
 
       ORG_INGESTERS[name] = ingester if type == :organisation

--- a/app/lib/dmao/ingesters.rb
+++ b/app/lib/dmao/ingesters.rb
@@ -1,0 +1,20 @@
+module DMAO
+  module Ingesters
+
+    ALL = []
+    DETAILS = {}
+    ORG_INGESTERS = {}
+
+    def self.register name, display_name, version, type, ingester
+
+      details = { name: name, display_name: display_name, version: version, type: type }
+
+      ALL.insert -1, name
+      DETAILS[name] = details
+
+      ORG_INGESTERS[name] = ingester if type == :organisation
+
+    end
+
+  end
+end

--- a/test/lib/dmao/ingesters_test.rb
+++ b/test/lib/dmao/ingesters_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+
+module DMAO
+  class IngestersTest < ActiveSupport::TestCase
+
+    test 'add new organisation ingester using register' do
+
+      DMAO::Ingesters.register(:ingester_name, "INGESTER Name", 0.1, :organisation, String)
+
+      details_hash = {
+          name: :ingester_name,
+          display_name: "INGESTER Name",
+          version: 0.1,
+          type: :organisation
+      }
+
+      assert_equal 1, DMAO::Ingesters::ALL.select { |v| v == :ingester_name }.size
+      assert_equal 1, DMAO::Ingesters::ORG_INGESTERS.select { |v| v == :ingester_name }.size
+      assert_equal details_hash, DMAO::Ingesters::DETAILS[:ingester_name]
+      assert_equal String, DMAO::Ingesters::ORG_INGESTERS[:ingester_name]
+
+      DMAO::Ingesters::ALL.delete(:ingester_name)
+      DMAO::Ingesters::DETAILS.delete(:ingester_name)
+      DMAO::Ingesters::ORG_INGESTERS.delete(:ingester_name)
+
+    end
+
+    test 'add new ingester with generic type using register' do
+
+      DMAO::Ingesters.register(:ingester_name, "INGESTER Name", 0.1, :testing, String)
+
+      details_hash = {
+          name: :ingester_name,
+          display_name: "INGESTER Name",
+          version: 0.1,
+          type: :testing
+      }
+
+      assert_equal 1, DMAO::Ingesters::ALL.select { |v| v == :ingester_name }.size
+      assert_equal 0, DMAO::Ingesters::ORG_INGESTERS.select { |v| v == :ingester_name }.size
+      assert_equal details_hash, DMAO::Ingesters::DETAILS[:ingester_name]
+
+      DMAO::Ingesters::ALL.delete(:ingester_name)
+      DMAO::Ingesters::DETAILS.delete(:ingester_name)
+
+    end
+
+  end
+end


### PR DESCRIPTION
Made available an ingesters module with constants to hold all registers ingesters for DMAO. Provides a simple register method to register new ingesters and store them in the constant based on their type.

Currently only supports the `:organisation` type.