### PR TITLE
Adding sentry support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 config/database.yml
 config/redis.yml
 config/dmao.yml
+config/sentry.yml
 
 vendor/assets/components
 public/assets/

--- a/Gemfile
+++ b/Gemfile
@@ -52,6 +52,9 @@ gem 'symmetric-encryption'
 gem 'redis'
 gem 'redis-namespace'
 
+# Application Error Monitoring
+gem "sentry-raven"
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,6 +92,8 @@ GEM
     docile (1.1.5)
     erubis (2.7.0)
     execjs (2.7.0)
+    faraday (0.9.2)
+      multipart-post (>= 1.2, < 3)
     ffi (1.9.14)
     font-awesome-rails (4.6.3.1)
       railties (>= 3.2, < 5.1)
@@ -125,6 +127,7 @@ GEM
     mocha (1.1.0)
       metaclass (~> 0.0.1)
     multi_json (1.12.1)
+    multipart-post (2.0.0)
     nested_form_fields (0.7.8)
       coffee-rails (>= 3.2.1)
       jquery-rails
@@ -191,6 +194,8 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    sentry-raven (1.2.3)
+      faraday (>= 0.7.6, < 0.10.x)
     simplecov (0.12.0)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
@@ -263,6 +268,7 @@ DEPENDENCIES
   redis
   redis-namespace
   sass-rails (~> 5.0)
+  sentry-raven
   spring
   spring-watcher-listen (~> 2.0.0)
   symmetric-encryption

--- a/app/controllers/admin/admin_controller.rb
+++ b/app/controllers/admin/admin_controller.rb
@@ -3,6 +3,13 @@ module Admin
   class AdminController < ApplicationController
 
     before_action :authenticate_dmao_admin!
+    before_action :set_raven_admin_context
+
+    private
+
+    def set_raven_admin_context
+      Raven.user_context(id: current_dmao_admin.id, type: "DMAO Admin")
+    end
 
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,12 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+
+  before_action :set_raven_context
+
+  private
+
+  def set_raven_context
+    Raven.extra_context(params: params.to_h, url: request.url)
+  end
+
 end

--- a/app/controllers/institutions/institutions_controller.rb
+++ b/app/controllers/institutions/institutions_controller.rb
@@ -5,6 +5,13 @@ module Institutions
     include Institutions::InstitutionDetails
 
     before_action :authenticate_institution_admin!
+    before_action :set_raven_institution_context
+
+    private
+
+    def set_raven_institution_context
+      Raven.user_context(id: current_institution_admin.id, type: "Institution Admin", institution_id: current_institution.id)
+    end
 
   end
 

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -29,7 +29,7 @@ set :rbenv_map_bins, %w{rake gem bundle ruby rails}
 # set :pty, true
 
 # Default value for :linked_files is []
-append :linked_files, 'config/database.yml', 'config/secrets.yml', 'config/symmetric-encryption.yml', 'config/redis.yml'
+append :linked_files, 'config/database.yml', 'config/secrets.yml', 'config/symmetric-encryption.yml', 'config/redis.yml', 'config/sentry.yml'
 
 # Default value for linked_dirs is []
 append :linked_dirs, 'log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'public/system'

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,5 @@
+Raven.configure do |config|
+  config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+  config.dsn = Rails.application.config_for(:sentry)["dsn"]
+  config.environments = Rails.application.config_for(:sentry)["environments"]
+end

--- a/config/sentry.yml.example
+++ b/config/sentry.yml.example
@@ -1,0 +1,9 @@
+default: &default
+  dsn: ''
+  environments: []
+development:
+  <<: *default
+test:
+  <<: *default
+production:
+  <<: *default


### PR DESCRIPTION
Adding support for [sentry](http://sentry.io) to help with error reporting of errors with DMA Online running in staging or production.