### PR TITLE
Add ingester type when registering ingesters

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -24,6 +24,7 @@ engines:
     enabled: true
     exclude_fingerprints:
     - 1800b7dde7bb9294e06a5b85c19c138b
+    - 8783d3d9e80ed734768fbdb29422ad44 # Parameters > 5 in register ingester method
 ratings:
   paths:
   - Gemfile.lock

--- a/app/lib/dmao/ingesters.rb
+++ b/app/lib/dmao/ingesters.rb
@@ -4,13 +4,16 @@ module DMAO
     ALL = []
     DETAILS = {}
     ORG_INGESTERS = {}
+    FILE_INGESTERS = []
 
-    def self.register name, display_name, version, type, ingester
+    def self.register name, display_name, version, type, ingester, ingester_type=nil
 
-      details = { name: name, display_name: display_name, version: version, type: type }
+      details = { name: name, display_name: display_name, version: version, type: type, ingester_type: ingester_type }
 
       ALL.insert(-1, name)
       DETAILS[name] = details
+
+      FILE_INGESTERS.insert(-1, name) if ingester_type == :file
 
       ORG_INGESTERS[name] = ingester if type == :organisation
 

--- a/app/lib/dmao/ingesters.rb
+++ b/app/lib/dmao/ingesters.rb
@@ -6,7 +6,11 @@ module DMAO
     ORG_INGESTERS = {}
     FILE_INGESTERS = []
 
+    VALID_INGESTER_TYPES = [:file, nil]
+
     def self.register name, display_name, version, type, ingester, ingester_type=nil
+
+      raise DMAO::Ingesters::Errors::InvalidIngesterType.new unless VALID_INGESTER_TYPES.include? ingester_type
 
       details = { name: name, display_name: display_name, version: version, type: type, ingester_type: ingester_type }
 

--- a/app/lib/dmao/ingesters/errors/invalid_ingester_type.rb
+++ b/app/lib/dmao/ingesters/errors/invalid_ingester_type.rb
@@ -1,0 +1,17 @@
+module DMAO
+  module Ingesters
+    module Errors
+
+      class InvalidIngesterType < StandardError
+
+        def initialize(msg="Invalid ingester type specified valid ingester types are #{DMAO::Ingesters::VALID_INGESTER_TYPES}")
+
+          super(msg)
+
+        end
+
+      end
+
+    end
+  end
+end

--- a/config/initializers/ingesters.rb
+++ b/config/initializers/ingesters.rb
@@ -1,1 +1,1 @@
-DMAO::Ingesters.register :json_organisation_ingester, "JSON Organisation Ingester", 0.1, :organisation, JSONIngesters::OrganisationIngester
+DMAO::Ingesters.register :json_organisation_ingester, "JSON Organisation Ingester", 0.1, :organisation, JSONIngesters::OrganisationIngester, :file

--- a/test/lib/dmao/ingesters_test.rb
+++ b/test/lib/dmao/ingesters_test.rb
@@ -11,7 +11,8 @@ module DMAO
           name: :ingester_name,
           display_name: "INGESTER Name",
           version: 0.1,
-          type: :organisation
+          type: :organisation,
+          ingester_type: nil
       }
 
       assert_equal 1, DMAO::Ingesters::ALL.select { |v| v == :ingester_name }.size
@@ -33,7 +34,8 @@ module DMAO
           name: :ingester_name,
           display_name: "INGESTER Name",
           version: 0.1,
-          type: :testing
+          type: :testing,
+          ingester_type: nil
       }
 
       assert_equal 1, DMAO::Ingesters::ALL.select { |v| v == :ingester_name }.size
@@ -42,6 +44,30 @@ module DMAO
 
       DMAO::Ingesters::ALL.delete(:ingester_name)
       DMAO::Ingesters::DETAILS.delete(:ingester_name)
+
+    end
+
+    test 'add new ingester with organisation type and ingester type as file' do
+
+      DMAO::Ingesters.register(:ingester_name, "INGESTER Name", 0.1, :organisation, String, :file)
+
+      details_hash = {
+          name: :ingester_name,
+          display_name: "INGESTER Name",
+          version: 0.1,
+          type: :organisation,
+          ingester_type: :file
+      }
+
+      assert_equal 1, DMAO::Ingesters::ALL.select { |v| v == :ingester_name }.size
+      assert_equal 1, DMAO::Ingesters::ORG_INGESTERS.select { |v| v == :ingester_name }.size
+      assert_equal details_hash, DMAO::Ingesters::DETAILS[:ingester_name]
+      assert_equal 1, DMAO::Ingesters::FILE_INGESTERS.select { |v| v == :ingester_name }.size
+
+      DMAO::Ingesters::ALL.delete(:ingester_name)
+      DMAO::Ingesters::DETAILS.delete(:ingester_name)
+      DMAO::Ingesters::ORG_INGESTERS.delete(:ingester_name)
+      DMAO::Ingesters::FILE_INGESTERS.delete(:ingester_name)
 
     end
 

--- a/test/lib/dmao/ingesters_test.rb
+++ b/test/lib/dmao/ingesters_test.rb
@@ -71,5 +71,18 @@ module DMAO
 
     end
 
+    test 'should raise invalid ingester type if not in the valid array' do
+
+      assert_raises DMAO::Ingesters::Errors::InvalidIngesterType do
+        DMAO::Ingesters.register(:ingester_name, "INGESTER Name", 0.1, :organisation, String, :invalid)
+      end
+
+      DMAO::Ingesters::ALL.delete(:ingester_name)
+      DMAO::Ingesters::DETAILS.delete(:ingester_name)
+      DMAO::Ingesters::ORG_INGESTERS.delete(:ingester_name)
+      DMAO::Ingesters::FILE_INGESTERS.delete(:ingester_name)
+
+    end
+
   end
 end


### PR DESCRIPTION
Provides a attribute to define the ingester type when registering a new ingester with a constant array to store all file ingesters in.

Raises an exception if the ingester type is not one of those specified.