### PR TITLE
Add user area dashboards

### DIFF
--- a/app/controllers/admin/admin_controller.rb
+++ b/app/controllers/admin/admin_controller.rb
@@ -2,6 +2,8 @@ module Admin
 
   class AdminController < ApplicationController
 
+    layout 'admin'
+
     before_action :authenticate_dmao_admin!
     before_action :set_raven_admin_context
 

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,0 +1,10 @@
+module Admin
+
+  class DashboardController < AdminController
+
+    def dashboard
+    end
+
+  end
+
+end

--- a/app/controllers/admin/dmao_admins/sessions_controller.rb
+++ b/app/controllers/admin/dmao_admins/sessions_controller.rb
@@ -2,6 +2,15 @@ module Admin
   module DmaoAdmins
     class SessionsController < Devise::SessionsController
       layout 'auth'
+
+      private
+
+      def after_sign_out_path_for(resource)
+
+        stored_location_for(resource) || admin_dashboard_path
+
+      end
+
     end
   end
 end

--- a/app/controllers/institutions/admin/sessions_controller.rb
+++ b/app/controllers/institutions/admin/sessions_controller.rb
@@ -8,6 +8,14 @@ module Institutions
 
       layout 'auth'
 
+      private
+
+      def after_sign_out_path_for(resource)
+
+        stored_location_for(resource) || institution_dashboard_path
+
+      end
+
     end
 
   end

--- a/app/controllers/institutions/dashboard_controller.rb
+++ b/app/controllers/institutions/dashboard_controller.rb
@@ -1,0 +1,10 @@
+module Institutions
+
+  class DashboardController < InstitutionsController
+
+    def dashboard
+    end
+
+  end
+
+end

--- a/app/controllers/institutions/institutions_controller.rb
+++ b/app/controllers/institutions/institutions_controller.rb
@@ -2,6 +2,8 @@ module Institutions
 
   class InstitutionsController < ApplicationController
 
+    layout 'institution_admin'
+
     include Institutions::InstitutionDetails
 
     before_action :authenticate_institution_admin!

--- a/app/views/admin/dashboard/dashboard.html.erb
+++ b/app/views/admin/dashboard/dashboard.html.erb
@@ -1,0 +1,3 @@
+<h2>Dashboard for admin area</h2>
+
+<h4>Current User <%= current_dmao_admin.name %></h4>

--- a/app/views/institutions/dashboard/dashboard.html.erb
+++ b/app/views/institutions/dashboard/dashboard.html.erb
@@ -1,0 +1,3 @@
+<h2>Dashboard for institution admin area</h2>
+
+<h4>Current User <%= current_institution_admin.name %></h4>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title><%= content_for?(:title) ? yield(:title) : "DMA Online" %> </title>
+
+  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+
+  <%= csrf_meta_tags %>
+  <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
+
+  <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
+  <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+  <!--[if lt IE 9]>
+  <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
+  <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+  <![endif]-->
+
+</head>
+
+<body class="hold-transition skin-blue sidebar-mini">
+
+<div class="wrapper">
+
+  <%= render "partials/header" %>
+
+  <%= render "partials/sidebar" %>
+
+  <div class="content-wrapper">
+
+    <section class="content-header">
+      <h1>
+        <%= content_for?(:title) ? yield(:title) : "DMA Online" %>
+      </h1>
+    </section>
+
+    <section class="content">
+
+      <%= yield %>
+
+    </section>
+
+  </div>
+
+  <%= render "partials/footer" %>
+
+</div>
+
+<%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+
+</body>
+</html>

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -21,9 +21,9 @@
 
 <div class="wrapper">
 
-  <%= render "partials/header" %>
+  <%= render "partials/admin/header" %>
 
-  <%= render "partials/sidebar" %>
+  <%= render "partials/admin/sidebar" %>
 
   <div class="content-wrapper">
 

--- a/app/views/layouts/institution_admin.html.erb
+++ b/app/views/layouts/institution_admin.html.erb
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title><%= content_for?(:title) ? yield(:title) : "DMA Online" %> </title>
+
+  <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
+
+  <%= csrf_meta_tags %>
+  <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
+
+  <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
+  <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+  <!--[if lt IE 9]>
+  <script src="https://oss.maxcdn.com/html5shiv/3.7.3/html5shiv.min.js"></script>
+  <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+  <![endif]-->
+
+</head>
+
+<body class="hold-transition skin-blue sidebar-mini">
+
+<div class="wrapper">
+
+  <%= render "partials/institution_admin/header" %>
+
+  <%= render "partials/institution_admin/sidebar" %>
+
+  <div class="content-wrapper">
+
+    <section class="content-header">
+      <h1>
+        <%= content_for?(:title) ? yield(:title) : "DMA Online" %>
+      </h1>
+    </section>
+
+    <section class="content">
+
+      <%= yield %>
+
+    </section>
+
+  </div>
+
+  <%= render "partials/footer" %>
+
+</div>
+
+<%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
+
+</body>
+</html>

--- a/app/views/partials/_header.html.erb
+++ b/app/views/partials/_header.html.erb
@@ -1,12 +1,12 @@
 <header class="main-header">
 
   <!-- Logo -->
-  <a href="index2.html" class="logo">
-    <!-- mini logo for sidebar mini 50x50 pixels -->
-    <span class="logo-mini"><b>DMA</b></span>
-    <!-- logo for regular state and mobile devices -->
-    <span class="logo-lg"><b>DMA</b> Online</span>
-  </a>
+  <%= link_to root_path, class: "logo" do %>
+      <!-- mini logo for sidebar mini 50x50 pixels -->
+      <span class="logo-mini"><b>DMA</b></span>
+      <!-- logo for regular state and mobile devices -->
+      <span class="logo-lg"><b>DMA</b> Online</span>
+  <% end %>
 
   <!-- Header Navbar -->
   <nav class="navbar navbar-static-top" role="navigation">

--- a/app/views/partials/_sidebar.html.erb
+++ b/app/views/partials/_sidebar.html.erb
@@ -6,29 +6,6 @@
     <!-- Sidebar Menu -->
     <ul class="sidebar-menu">
       <li class="header"></li>
-      <li class="treeview <%= 'active' if params[:controller] == 'admin/institutions' %>">
-        <a href="#"><i class="fa fa-home"></i> <span>Institutions</span>
-          <span class="pull-right-container">
-              <i class="fa fa-angle-left pull-right"></i>
-            </span>
-        </a>
-        <ul class="treeview-menu">
-          <li class="<%= 'active' if ((params[:controller] == 'admin/institutions') && (params[:action] == 'index')) %>"><%= link_to "All Institutions", admin_institutions_path %></li>
-          <li class="<%= 'active' if ((params[:controller] == 'admin/institutions') && (params[:action] == 'new')) %>"><%= link_to "New Institution", new_admin_institution_path %></li>
-        </ul>
-      </li>
-
-      <li class="treeview <%= 'active' if !params[:controller].match(/^admin\/systems.*/).nil? %>">
-        <a href="#"><i class="fa fa-home"></i> <span>Systems</span>
-          <span class="pull-right-container">
-              <i class="fa fa-angle-left pull-right"></i>
-            </span>
-        </a>
-        <ul class="treeview-menu">
-          <li class="<%= 'active' if ((params[:controller] == 'admin/systems/cris_systems')) %>"><%= link_to "CRIS Systems", admin_systems_cris_systems_path %></li>
-        </ul>
-      </li>
-
     </ul>
     <!-- /.sidebar-menu -->
   </section>

--- a/app/views/partials/admin/_header.html.erb
+++ b/app/views/partials/admin/_header.html.erb
@@ -1,0 +1,18 @@
+<header class="main-header">
+
+  <!-- Logo -->
+  <%= link_to admin_dashboard_path, class: "logo" do %>
+    <!-- mini logo for sidebar mini 50x50 pixels -->
+    <span class="logo-mini"><b>DMA</b></span>
+    <!-- logo for regular state and mobile devices -->
+    <span class="logo-lg"><b>DMA</b> Online</span>
+  <% end %>
+
+  <!-- Header Navbar -->
+  <nav class="navbar navbar-static-top" role="navigation">
+    <!-- Sidebar toggle button-->
+    <a href="#" class="sidebar-toggle" data-toggle="offcanvas" role="button">
+      <span class="sr-only">Toggle navigation</span>
+    </a>
+  </nav>
+</header>

--- a/app/views/partials/admin/_sidebar.html.erb
+++ b/app/views/partials/admin/_sidebar.html.erb
@@ -1,0 +1,36 @@
+<aside class="main-sidebar">
+
+  <!-- sidebar: style can be found in sidebar.less -->
+  <section class="sidebar">
+
+    <!-- Sidebar Menu -->
+    <ul class="sidebar-menu">
+      <li class="header"></li>
+      <li class="treeview <%= 'active' if params[:controller] == 'admin/institutions' %>">
+        <a href="#"><i class="fa fa-home"></i> <span>Institutions</span>
+          <span class="pull-right-container">
+              <i class="fa fa-angle-left pull-right"></i>
+            </span>
+        </a>
+        <ul class="treeview-menu">
+          <li class="<%= 'active' if ((params[:controller] == 'admin/institutions') && (params[:action] == 'index')) %>"><%= link_to "All Institutions", admin_institutions_path %></li>
+          <li class="<%= 'active' if ((params[:controller] == 'admin/institutions') && (params[:action] == 'new')) %>"><%= link_to "New Institution", new_admin_institution_path %></li>
+        </ul>
+      </li>
+
+      <li class="treeview <%= 'active' if !params[:controller].match(/^admin\/systems.*/).nil? %>">
+        <a href="#"><i class="fa fa-home"></i> <span>Systems</span>
+          <span class="pull-right-container">
+              <i class="fa fa-angle-left pull-right"></i>
+            </span>
+        </a>
+        <ul class="treeview-menu">
+          <li class="<%= 'active' if ((params[:controller] == 'admin/systems/cris_systems')) %>"><%= link_to "CRIS Systems", admin_systems_cris_systems_path %></li>
+        </ul>
+      </li>
+
+    </ul>
+    <!-- /.sidebar-menu -->
+  </section>
+  <!-- /.sidebar -->
+</aside>

--- a/app/views/partials/institution_admin/_header.html.erb
+++ b/app/views/partials/institution_admin/_header.html.erb
@@ -1,12 +1,12 @@
 <header class="main-header">
 
   <!-- Logo -->
-  <a href="index2.html" class="logo">
-    <!-- mini logo for sidebar mini 50x50 pixels -->
-    <span class="logo-mini"><b>DMA</b></span>
-    <!-- logo for regular state and mobile devices -->
-    <span class="logo-lg"><b>DMA</b> Online</span>
-  </a>
+  <%= link_to institution_dashboard_path, class: "logo" do %>
+      <!-- mini logo for sidebar mini 50x50 pixels -->
+      <span class="logo-mini"><b>DMA</b></span>
+      <!-- logo for regular state and mobile devices -->
+      <span class="logo-lg"><b>DMA</b> Online</span>
+  <% end %>
 
   <!-- Header Navbar -->
   <nav class="navbar navbar-static-top" role="navigation">

--- a/app/views/partials/institution_admin/_header.html.erb
+++ b/app/views/partials/institution_admin/_header.html.erb
@@ -1,0 +1,18 @@
+<header class="main-header">
+
+  <!-- Logo -->
+  <a href="index2.html" class="logo">
+    <!-- mini logo for sidebar mini 50x50 pixels -->
+    <span class="logo-mini"><b>DMA</b></span>
+    <!-- logo for regular state and mobile devices -->
+    <span class="logo-lg"><b>DMA</b> Online</span>
+  </a>
+
+  <!-- Header Navbar -->
+  <nav class="navbar navbar-static-top" role="navigation">
+    <!-- Sidebar toggle button-->
+    <a href="#" class="sidebar-toggle" data-toggle="offcanvas" role="button">
+      <span class="sr-only">Toggle navigation</span>
+    </a>
+  </nav>
+</header>

--- a/app/views/partials/institution_admin/_sidebar.html.erb
+++ b/app/views/partials/institution_admin/_sidebar.html.erb
@@ -1,0 +1,13 @@
+<aside class="main-sidebar">
+
+  <!-- sidebar: style can be found in sidebar.less -->
+  <section class="sidebar">
+
+    <!-- Sidebar Menu -->
+    <ul class="sidebar-menu">
+      <li class="header"></li>
+    </ul>
+    <!-- /.sidebar-menu -->
+  </section>
+  <!-- /.sidebar -->
+</aside>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
       resources :cris_systems, controller: 'cris_systems'
       get 'cris_systems/:id/config_keys', to: 'cris_systems#config_keys'
     end
+    get '/', to: 'dashboard#dashboard', as: :dashboard
   end
 
   scope '/:institution_identifier', module: 'institutions' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,8 @@ Rails.application.routes.draw do
 
       resources :users
 
+      get '/', to: 'dashboard#dashboard', as: :dashboard
+
     end
 
   end


### PR DESCRIPTION
Add layouts and dashboard view for the different user areas to allow easier customising of the sidebar, header links and other styling and layout issue for the different user types of DMAO Admin and institution admin.

Updates the current controllers and layouts to reflect these new layouts.