### PR TITLE
Display institution configuration

### DIFF
--- a/app/models/configuration/system/cris_system.rb
+++ b/app/models/configuration/system/cris_system.rb
@@ -29,6 +29,30 @@ module Configuration
         @config_values.delete id
       end
 
+      def details
+
+        begin
+          ::Systems::CrisSystem.find(self.system_id)
+        rescue ActiveRecord::RecordNotFound
+          nil
+        end
+
+      end
+
+      def configuration_values
+
+        self.config_values.map do |v|
+
+          begin
+            ::Systems::ConfigurationValue.find(v)
+          rescue ActiveRecord::RecordNotFound
+            nil
+          end
+
+        end
+
+      end
+
       private
 
       def config_values_array

--- a/app/views/admin/institutions/show.html.erb
+++ b/app/views/admin/institutions/show.html.erb
@@ -115,7 +115,46 @@
 
           <div class="row">
             <div class="col-sm-12">
-              <h4>Institution Configuration to be displayed here</h4>
+              <% if @institution.configuration %>
+
+                <div class="box-group" id="accordion">
+                  <!-- we are adding the .panel class so bootstrap.js collapse plugin detects it -->
+                  <div class="panel box box-primary">
+                    <div class="box-header with-border">
+                      <h4 class="box-title">
+                        <a data-toggle="collapse" data-parent="#accordion" href="#crisSystem">
+                          Cris System Configuration
+                        </a>
+                      </h4>
+                    </div>
+                    <div id="crisSystem" class="panel-collapse collapse in">
+                      <div class="box-body">
+                        <dl class="dl-horizontal">
+                          <dt>CRIS System</dt>
+                          <dd><%= @institution.configuration.systems_configuration.cris_system.details.name %></dd>
+                          <dd><%= @institution.configuration.systems_configuration.cris_system.details.description %></dd>
+                          <dd>Version: <%= @institution.configuration.systems_configuration.cris_system.details.version %></dd>
+                          <br>
+                          <% @institution.configuration.systems_configuration.cris_system.configuration_values.each do |v| %>
+                            <dd><%= v.configuration_key.display_name %>: <%= v.configuration_key.secure ? "SECURE CONFIG VALUE" : v.value %></dd>
+                          <% end %>
+                          <br>
+                          <dt>Organisation Ingester</dt>
+                          <dd><%= @institution.configuration.systems_configuration.cris_system.details.organisation_ingester %></dd>
+                          <dt>File based?</dt>
+                          <dd><%= DMAO::Ingesters::FILE_INGESTERS.include? @institution.configuration.systems_configuration.cris_system.details.organisation_ingester.to_sym %></dd>
+                        </dl>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+              <% else %>
+
+                  <%= link_to "New Configuration", new_admin_institution_configuration_path(institution_id: @institution), class: "btn btn-block btn-primary" %>
+
+              <% end %>
+
             </div>
           </div>
 

--- a/test/models/configuration/system/cris_system_test.rb
+++ b/test/models/configuration/system/cris_system_test.rb
@@ -72,6 +72,48 @@ module Configuration
 
       end
 
+      test 'details should return nil for invalid system id' do
+
+        assert_nil @cris_system.details
+
+      end
+
+      test 'details should return instance of systems cris system when valid system id' do
+
+        @cris_system.system_id = systems_cris_systems(:one).id
+
+        assert_instance_of ::Systems::CrisSystem, @cris_system.details
+
+      end
+
+      test 'configuration values should return array of configuration values for all valid config values' do
+
+        @cris_system.config_values = [systems_configuration_values(:one).id]
+
+        assert_instance_of Array, @cris_system.configuration_values
+
+        @cris_system.configuration_values.each do |v|
+
+          assert_instance_of ::Systems::ConfigurationValue, v
+
+        end
+
+      end
+
+      test 'configuration values should return array of configuration values with nil for invalid config value id' do
+
+        @cris_system.config_values = [systems_configuration_values(:one).id, 0]
+
+        config_values = @cris_system.configuration_values
+
+        assert_instance_of Array, config_values
+
+        assert_instance_of ::Systems::ConfigurationValue, config_values[0]
+
+        assert_nil config_values[1]
+
+      end
+
     end
   end
 end


### PR DESCRIPTION
Within the DMAO Admin area display the current configuration for the Institution, this currently displays the CRIS System configuration with a list of its ingesters.