### PR TITLE
Add manual ingest job for institution

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,8 @@ gem "sentry-raven"
 # File uploads and Asset storing
 gem 'carrierwave'
 
+gem 'remotipart', '~> 1.3'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,6 +191,7 @@ GEM
     redis (3.3.1)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
+    remotipart (1.3.0)
     request_store (1.3.1)
     responders (2.2.0)
       railties (>= 4.2.0, < 5.1)
@@ -275,6 +276,7 @@ DEPENDENCIES
   rails-controller-testing
   redis
   redis-namespace
+  remotipart (~> 1.3)
   sass-rails (~> 5.0)
   sentry-raven
   spring

--- a/app/assets/javascripts/admin/institutions/ingests.js
+++ b/app/assets/javascripts/admin/institutions/ingests.js
@@ -1,0 +1,2 @@
+$("#new_ingest_job").on("ajax:success", function(e, data, status, xhr) {
+});

--- a/app/assets/javascripts/admin/institutions/ingests.js
+++ b/app/assets/javascripts/admin/institutions/ingests.js
@@ -1,2 +1,11 @@
 $("#new_ingest_job").on("ajax:success", function(e, data, status, xhr) {
+
+    var alert = '<div class="alert alert-success alert-dismissible">';
+    alert += '<button type="button" class="close" data-dismiss="alert" aria-hidden="true">&times;</button>';
+    alert += '<h4><i class="icon fa fa-check"></i> Successfully added ingest!</h4>';
+    alert += 'Manual ingest has been added to the system.';
+    alert += '</div>';
+
+    $("#ingest-jobs > .row > .alerts").append(alert);
+
 });

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -12,6 +12,7 @@
 //
 //= require jquery
 //= require jquery_ujs
+//= require jquery.remotipart
 //= require bootstrap-sprockets
 //= require adminlte
 //= require nested_form_fields

--- a/app/controllers/admin/institutions/ingest_jobs_controller.rb
+++ b/app/controllers/admin/institutions/ingest_jobs_controller.rb
@@ -1,0 +1,55 @@
+module Admin
+
+  module Institutions
+
+    class IngestJobsController < AdminController
+
+      def create
+
+        begin
+
+          institution = Institution.find params[:institution_id]
+
+          @ingest_job = create_new_ingest_job institution
+
+          @ingest_job.save
+
+          respond_to do |format|
+
+            format.json { render json: @ingest_job }
+            format.js
+          end
+
+        rescue ActiveRecord::RecordNotFound, ActionController::UnknownFormat
+
+          head(:not_found)
+
+        end
+
+      end
+
+      private
+
+      def create_new_ingest_job institution
+
+        ingest_job = {
+            ingest_type: "ingest",
+            ingest_mode: "manual",
+            ingest_area: params[:ingest_job][:ingest_area],
+            institution: institution,
+            status: "new"
+        }
+
+        ingest_job = IngestJob.new ingest_job
+
+        ingest_job.ingest_data_file = params[:ingest_job][:ingest_data_file]
+
+        ingest_job
+
+      end
+
+    end
+
+  end
+
+end

--- a/app/lib/dmao/ingesters.rb
+++ b/app/lib/dmao/ingesters.rb
@@ -8,6 +8,9 @@ module DMAO
 
     VALID_INGESTER_TYPES = [:file, nil]
 
+    VALID_INGEST_AREAS = [:organisation]
+    INGEST_AREA_DISPLAY_NAMES = { organisation: "Organisation Structure" }
+
     def self.register name, display_name, version, type, ingester, ingester_type=nil
 
       raise DMAO::Ingesters::Errors::InvalidIngesterType.new unless VALID_INGESTER_TYPES.include? ingester_type

--- a/app/views/admin/institutions/ingest_jobs/create.js.erb
+++ b/app/views/admin/institutions/ingest_jobs/create.js.erb
@@ -1,0 +1,3 @@
+$("#newIngest").modal('toggle');
+$("#ingest_job_ingest_area").val('');
+$("#ingest_job_ingest_data_file").val('');

--- a/app/views/admin/institutions/show.html.erb
+++ b/app/views/admin/institutions/show.html.erb
@@ -165,11 +165,15 @@
 
           <div class="row">
 
-            <div class="col-sm-12" style="padding-bottom: 10px;">
-              <button type="button" class="btn btn-primary pull-right" data-toggle="modal" data-target="#newIngest">
-                Manual Ingest
-              </button>
-            </div>
+            <% if DMAO::Ingesters::FILE_INGESTERS.include? @institution.configuration.systems_configuration.cris_system.details.organisation_ingester.to_sym %>
+
+              <div class="col-sm-12" style="padding-bottom: 10px;">
+                <button type="button" class="btn btn-primary pull-right" data-toggle="modal" data-target="#newIngest">
+                  Manual Ingest
+                </button>
+              </div>
+
+            <% end %>
 
             <div class="col-sm-12">
 

--- a/app/views/admin/institutions/show.html.erb
+++ b/app/views/admin/institutions/show.html.erb
@@ -163,6 +163,12 @@
 
         <div class="tab-pane" id="ingest-jobs">
 
+          <div class="row">
+            <div class="col-sm-12 alerts">
+
+            </div>
+          </div>
+
           <% if @institution.configuration %>
 
           <div class="row">

--- a/app/views/admin/institutions/show.html.erb
+++ b/app/views/admin/institutions/show.html.erb
@@ -163,6 +163,8 @@
 
         <div class="tab-pane" id="ingest-jobs">
 
+          <% if @institution.configuration %>
+
           <div class="row">
 
             <% if DMAO::Ingesters::FILE_INGESTERS.include? @institution.configuration.systems_configuration.cris_system.details.organisation_ingester.to_sym %>
@@ -212,6 +214,20 @@
 
             </div>
           </div>
+
+          <% else %>
+
+          <div class="row">
+
+            <div class="col-sm-12">
+
+              <h3>No institution configuration, cannot ingest data for an institution that has no configuration.</h3>
+
+            </div>
+
+          </div>
+
+          <% end %>
 
         </div>
 

--- a/app/views/admin/institutions/show.html.erb
+++ b/app/views/admin/institutions/show.html.erb
@@ -334,15 +334,19 @@
             <span aria-hidden="true">&times;</span></button>
           <h4 class="modal-title">Manual Ingest</h4>
         </div>
-        <%= form_for @institution.ingest_jobs.new, url: admin_institutions_path(@institution), html: { class: "form-horizontal" } do |f| %>
+        <%= form_for @institution.ingest_jobs.new, url: admin_institution_ingest_jobs_path(@institution), remote: true, authenticity_token: true, html: { class: "form-horizontal" } do |f| %>
         <div class="modal-body">
+
+          <div id="ingest_error_explanation">
+
+          </div>
 
               <div class="form-group">
 
                 <%= f.label :ingest_area, class: "col-sm-3 control-label" %>
 
                 <div class="col-sm-9">
-                  <%= f.select :ingest_area, options_for_select([["Organisation Structure", "organisation"]]), { include_blank: 'Choose Ingest Area' }, { class: "form-control" } %>
+                  <%= f.select :ingest_area, options_for_select(DMAO::Ingesters::INGEST_AREA_DISPLAY_NAMES.collect { |k, v| [v, k] }), { include_blank: 'Choose Ingest Area' }, { class: "form-control" } %>
                 </div>
 
               </div>

--- a/app/views/admin/institutions/show.html.erb
+++ b/app/views/admin/institutions/show.html.erb
@@ -164,6 +164,13 @@
         <div class="tab-pane" id="ingest-jobs">
 
           <div class="row">
+
+            <div class="col-sm-12" style="padding-bottom: 10px;">
+              <button type="button" class="btn btn-primary pull-right" data-toggle="modal" data-target="#newIngest">
+                Manual Ingest
+              </button>
+            </div>
+
             <div class="col-sm-12">
 
               <div class="box table-responsive">
@@ -314,4 +321,49 @@
     <!-- /.nav-tabs-custom -->
   </div>
   <!-- /.col -->
+
+  <div class="modal fade" id="newIngest" tabindex="-1" role="dialog">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header bg-primary">
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span></button>
+          <h4 class="modal-title">Manual Ingest</h4>
+        </div>
+        <%= form_for @institution.ingest_jobs.new, url: admin_institutions_path(@institution), html: { class: "form-horizontal" } do |f| %>
+        <div class="modal-body">
+
+              <div class="form-group">
+
+                <%= f.label :ingest_area, class: "col-sm-3 control-label" %>
+
+                <div class="col-sm-9">
+                  <%= f.select :ingest_area, options_for_select([["Organisation Structure", "organisation"]]), { include_blank: 'Choose Ingest Area' }, { class: "form-control" } %>
+                </div>
+
+              </div>
+
+              <div class="form-group">
+
+                <%= f.label :ingest_data_file, class: "col-sm-3 control-label" %>
+
+                <div class="col-sm-9">
+                  <%= f.file_field :ingest_data_file %>
+                </div>
+
+              </div>
+
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-default pull-left" data-dismiss="modal">Cancel</button>
+          <%= f.submit class: "btn btn-primary" %>
+        </div>
+        <% end %>
+      </div>
+      <!-- /.modal-content -->
+    </div>
+    <!-- /.modal-dialog -->
+  </div>
+  <!-- /.modal -->
+
 </div>

--- a/app/views/admin/institutions/show.html.erb
+++ b/app/views/admin/institutions/show.html.erb
@@ -99,6 +99,7 @@
       <ul class="nav nav-tabs">
         <li class="active"><a href="#admin-users" data-toggle="tab"><i class="fa fa-users margin-r-5"></i> Admin Users</a></li>
         <li><a href="#configuration" data-toggle="tab"><i class="fa fa-cogs margin-r-5"></i> Configuration</a></li>
+        <li><a href="#ingest-jobs" data-toggle="tab"><i class="fa fa-cloud-download margin-r-5"></i> Ingests</a></li>
         <li><a href="#settings" data-toggle="tab"><i class="fa fa-cog margin-r-5"></i> Settings</a></li>
       </ul>
       <div class="tab-content">
@@ -154,6 +155,49 @@
                   <%= link_to "New Configuration", new_admin_institution_configuration_path(institution_id: @institution), class: "btn btn-block btn-primary" %>
 
               <% end %>
+
+            </div>
+          </div>
+
+        </div>
+
+        <div class="tab-pane" id="ingest-jobs">
+
+          <div class="row">
+            <div class="col-sm-12">
+
+              <div class="box table-responsive">
+                <div class="box-body no-padding">
+                  <table class="table table-striped table-hover table-align-center">
+                    <thead>
+                    <tr>
+                      <th>ID</th>
+                      <th>Ingest Time</th>
+                      <th>Ingest Status</th>
+                      <th>Type</th>
+                      <th>Mode</th>
+                      <th>Area</th>
+                      <th>Log File</th>
+                      <th>Data File</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <% @institution.ingest_jobs.each do |job| %>
+                        <tr>
+                          <th scope="row"><%= job.id %></th>
+                          <td><%= job.ingest_time %></td>
+                          <td><%= job.status %></td>
+                          <td><%= job.ingest_type %></td>
+                          <td><%= job.ingest_mode %></td>
+                          <td><%= job.ingest_area %></td>
+                          <td><%= job.ingest_log_file %></td>
+                          <td><%= job.ingest_data_file %></td>
+                        </tr>
+                    <% end %>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
 
             </div>
           </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,6 +28,7 @@ Rails.application.routes.draw do
     resources :institutions do
       resources :admins, controller: 'institutions/admins'
       resources :configurations, controller: 'institutions/configurations'
+      resources :ingest_jobs, controller: 'institutions/ingest_jobs'
     end
     namespace :systems do
       resources :cris_systems, controller: 'cris_systems'

--- a/test/controllers/admin/institutions/ingest_jobs_controller_test.rb
+++ b/test/controllers/admin/institutions/ingest_jobs_controller_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+
+module Admin
+
+  module Institutions
+
+    class IngestJobsControllerTest < ActionController::TestCase
+
+      include Devise::Test::ControllerHelpers
+
+      def setup
+
+        @request.env['devise.mapping'] = Devise.mappings[:dmao_admin]
+        sign_in dmao_admins(:one)
+
+        @institution = institutions(:luve)
+
+      end
+
+      test 'Create - should return status 200 with template when requesting as js' do
+
+        post :create, xhr: true, params: { institution_id: @institution.id, ingest_job: { ingest_area: "organisation", ingest_data_file: fixture_file_upload("files/json_organisation_units.json") } }
+
+        assert_template :create
+        assert_response :ok
+        assert assigns(:ingest_job)
+
+      end
+
+      test 'Create - should return 404 when requesting as js with invalid institution id' do
+
+        post :create, xhr: true, params: { institution_id: 0, ingest_job: { ingest_area: "organisation", ingest_data_file: fixture_file_upload("files/json_organisation_units.json") } }
+
+        assert_response :not_found
+
+      end
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
Adds a new manual ingest job from the institution ingests view. Adds the ingest to the system with the data file for ingesting.

This does not schedule a background job for processing, it only adds the ingest job to the database so it can then be referenced for further processing and keeping a history of ingests that have happened.