### PR TITLE
Saving Institution Configuration

### DIFF
--- a/app/services/create_systems_configuration.rb
+++ b/app/services/create_systems_configuration.rb
@@ -41,9 +41,7 @@ class CreateSystemsConfiguration
 
       config_key_values.keys.each do |k|
 
-        if config_key_ids.include?(k.to_i)
-
-        else
+        if !config_key_ids.include?(k.to_i)
 
           config_key_values.delete(k)
 
@@ -55,21 +53,15 @@ class CreateSystemsConfiguration
 
     end
 
-    if systems_configuration.errors.any?
-      return systems_configuration
-    end
+    return systems_configuration if systems_configuration.errors.any?
 
     # Store configuration key values
 
     if config_key_values.present?
 
-      config_key_values.each_pair do |k, v| 
+      config_key_values.each_pair do |k, v|
 
-        key = ::Systems::ConfigurationKey.find(k.to_i)
-
-        v = v.symbolize_keys
-
-        config_value = ::Systems::ConfigurationValue.create(institution: @institution, configuration_key: key, value: v[:value])
+        config_value = create_system_configuration_value k, v, @institution
 
         # set cris system configuration key
 
@@ -80,6 +72,18 @@ class CreateSystemsConfiguration
     end
 
     systems_configuration
+
+  end
+
+  private
+
+  def create_system_configuration_value config_key_id, value, institution
+
+    key = ::Systems::ConfigurationKey.find(config_key_id.to_i)
+
+    value = value.symbolize_keys
+
+    ::Systems::ConfigurationValue.create(institution: institution, configuration_key: key, value: value[:value])
 
   end
 

--- a/app/services/create_systems_configuration.rb
+++ b/app/services/create_systems_configuration.rb
@@ -51,15 +51,11 @@ class CreateSystemsConfiguration
 
       end
 
-    end
-
-    return systems_configuration if systems_configuration.errors.any?
-
-    # Store configuration key values
-
-    if config_key_values.present?
+      return systems_configuration if systems_configuration.errors.any?
 
       config_key_values.each_pair do |k, v|
+
+        # Store configuration key values
 
         config_value = create_system_configuration_value k, v, @institution
 

--- a/app/services/create_systems_configuration.rb
+++ b/app/services/create_systems_configuration.rb
@@ -37,15 +37,19 @@ class CreateSystemsConfiguration
 
     # check configurations key values are set for all config keys else errors
 
-    config_key_values.keys.each do |k|
+    if config_key_values.present?
 
-      if config_key_ids.include?(k.to_i)
+      config_key_values.keys.each do |k|
 
-      else
+        if config_key_ids.include?(k.to_i)
 
-        config_key_values.delete(k)
+        else
 
-        systems_configuration.errors.add(:cris_system, "Invalid configuration keys for choosen CRIS System specified.")
+          config_key_values.delete(k)
+
+          systems_configuration.errors.add(:cris_system, "Invalid configuration keys for choosen CRIS System specified.")
+
+        end
 
       end
 
@@ -57,17 +61,21 @@ class CreateSystemsConfiguration
 
     # Store configuration key values
 
-    config_key_values.each_pair do |k, v|
+    if config_key_values.present?
 
-      key = ::Systems::ConfigurationKey.find(k.to_i)
+      config_key_values.each_pair do |k, v| 
 
-      v = v.symbolize_keys
+        key = ::Systems::ConfigurationKey.find(k.to_i)
 
-      config_value = ::Systems::ConfigurationValue.create(institution: @institution, configuration_key: key, value: v[:value])
+        v = v.symbolize_keys
 
-      # set cris system configuration key
+        config_value = ::Systems::ConfigurationValue.create(institution: @institution, configuration_key: key, value: v[:value])
 
-      systems_configuration.cris_system.add_config_value config_value.id
+        # set cris system configuration key
+
+        systems_configuration.cris_system.add_config_value config_value.id
+
+      end
 
     end
 

--- a/app/views/admin/institutions/show.html.erb
+++ b/app/views/admin/institutions/show.html.erb
@@ -142,8 +142,6 @@
                           <br>
                           <dt>Organisation Ingester</dt>
                           <dd><%= @institution.configuration.systems_configuration.cris_system.details.organisation_ingester %></dd>
-                          <dt>File based?</dt>
-                          <dd><%= DMAO::Ingesters::FILE_INGESTERS.include? @institution.configuration.systems_configuration.cris_system.details.organisation_ingester.to_sym %></dd>
                         </dl>
                       </div>
                     </div>
@@ -172,16 +170,6 @@
           <% if @institution.configuration %>
 
           <div class="row">
-
-            <% if DMAO::Ingesters::FILE_INGESTERS.include? @institution.configuration.systems_configuration.cris_system.details.organisation_ingester.to_sym %>
-
-              <div class="col-sm-12" style="padding-bottom: 10px;">
-                <button type="button" class="btn btn-primary pull-right" data-toggle="modal" data-target="#newIngest">
-                  Manual Ingest
-                </button>
-              </div>
-
-            <% end %>
 
             <div class="col-sm-12">
 
@@ -347,53 +335,5 @@
     <!-- /.nav-tabs-custom -->
   </div>
   <!-- /.col -->
-
-  <div class="modal fade" id="newIngest" tabindex="-1" role="dialog">
-    <div class="modal-dialog">
-      <div class="modal-content">
-        <div class="modal-header bg-primary">
-          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-            <span aria-hidden="true">&times;</span></button>
-          <h4 class="modal-title">Manual Ingest</h4>
-        </div>
-        <%= form_for @institution.ingest_jobs.new, url: admin_institution_ingest_jobs_path(@institution), remote: true, authenticity_token: true, html: { class: "form-horizontal" } do |f| %>
-        <div class="modal-body">
-
-          <div id="ingest_error_explanation">
-
-          </div>
-
-              <div class="form-group">
-
-                <%= f.label :ingest_area, class: "col-sm-3 control-label" %>
-
-                <div class="col-sm-9">
-                  <%= f.select :ingest_area, options_for_select(DMAO::Ingesters::INGEST_AREA_DISPLAY_NAMES.collect { |k, v| [v, k] }), { include_blank: 'Choose Ingest Area' }, { class: "form-control" } %>
-                </div>
-
-              </div>
-
-              <div class="form-group">
-
-                <%= f.label :ingest_data_file, class: "col-sm-3 control-label" %>
-
-                <div class="col-sm-9">
-                  <%= f.file_field :ingest_data_file %>
-                </div>
-
-              </div>
-
-        </div>
-        <div class="modal-footer">
-          <button type="button" class="btn btn-default pull-left" data-dismiss="modal">Cancel</button>
-          <%= f.submit class: "btn btn-primary" %>
-        </div>
-        <% end %>
-      </div>
-      <!-- /.modal-content -->
-    </div>
-    <!-- /.modal-dialog -->
-  </div>
-  <!-- /.modal -->
 
 </div>


### PR DESCRIPTION
Add presence check to wrap adding config key values to catch CRIS Systems which do not have any config keys set on them and therefore no values specified.

Removes ability to view if an ingest is file based or not and add a manual ingest as these currently reference the removed local ingest functionality which has been moved to DMAO-Ingest-Service. Done within this PR as causes a crash exception when returning to the institution details after adding a configuration for a CRIS System with no config keys.