### PR TITLE
Capistrano lock version

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,5 @@
 # config valid only for current version of Capistrano
-lock '3.6.0'
+lock '3.6.1'
 
 set :application, 'DMAOnline'
 set :repo_url, 'git@github.com:lulibrary/DMAO.git'


### PR DESCRIPTION
Capistrano version was updated to 3.6.1 in PR #54 the Capistrano config file was not updated and only noticed upon deploying.